### PR TITLE
WaymoWatch v0.1: data plane + synthetic-positive engine

### DIFF
--- a/projects/waymowatch/.gitignore
+++ b/projects/waymowatch/.gitignore
@@ -1,0 +1,16 @@
+data/
+.venv/
+venv/
+node_modules/
+*.db
+*.db-wal
+*.db-shm
+__pycache__/
+*.pyc
+models/*.pt
+models/*.onnx
+.env
+
+# auto-downloaded model weights
+*.pt
+*.onnx

--- a/projects/waymowatch/CHANGELOG.md
+++ b/projects/waymowatch/CHANGELOG.md
@@ -1,0 +1,33 @@
+# WaymoWatch — Changelog
+
+## v0.1 — Data plane + synthetic-positive engine (2026-06-03)
+
+First working slice. Detect-and-train infrastructure not built yet; this proves the two
+hardest unknowns are tractable.
+
+### What works (verified live with OpenCV, no GPU)
+- **Collector** (`collector/data_plane.py`): enumerates all **882** TfL JamCams (779 available),
+  conditional-GETs each camera's ~11s H.264 clip from S3 (ETag dedup), decodes with OpenCV,
+  extracts frames at a configurable sample rate, records cameras/clips/frames in SQLite.
+  - Baseline: 12 central cams → 12 clips, 637 frames in ~70s (single-threaded → needs
+    parallelism at 779-cam scale).
+- **Source imagery** (`dataset/fetch_sources.py`): 28 CC-licensed images from Wikimedia Commons —
+  1 clean Waymo dome reference + many ordinary I-PACEs (negatives). Manifest records per-image licence.
+- **Copy-paste engine** (`dataset/copy_paste.py`): `jamcam_degrade`, `composite`, `simulate_at_scale`.
+- **Synthetic positives** (`dataset/make_synthetic.py`): detect cars (YOLO11n COCO) in real London
+  backplates → paste a real Waymo dome on resolvable-size roofs (≥30px, aspect-ratio gated) →
+  brightness-match + feather → re-degrade to JamCam JPEG → emit YOLO labels. **80 positives generated.**
+
+### Baseline facts to watch
+- TfL clip = 25fps / ~11s / 277 frames / 352×288, refreshed ~3–8 min. Full video sweep ≈ 216k
+  frames/3min → sample every 5th (56f/clip) → 242fps required → needs 1 small GPU (Phase 5).
+- **Dome resolvable only when host vehicle ≳45px tall** (`data/sources/dome_scale_test.jpg`).
+- No off-the-shelf dataset/model fits (ego-viewpoint or non-commercial). Our JamCam frames + the
+  copy-paste engine are the data strategy.
+
+### Next
+- Harvest more dome crops via yt-dlp/ffmpeg (YouTube/news) for angle variety.
+- Generate matched negatives; assemble dataset.yaml (2 classes: waymo, wayve).
+- Autolabel pipeline (YOLOE proposer + Claude dome/bar classifier) for real frames.
+- Train WaymoNet v0 (YOLO11s + P2 head) on a rented 4090; eval by held-out clip; ship-gate P≥0.9.
+- Two-stage inference runtime + Leaflet sighting feed + WhatsApp alerts.

--- a/projects/waymowatch/README.md
+++ b/projects/waymowatch/README.md
@@ -1,0 +1,58 @@
+# WaymoWatch
+
+Spot and log Waymo autonomous test vehicles on London's streets from TfL's public
+traffic-camera (JamCam) feeds, using a purpose-trained detector (**WaymoNet**), then
+turn confirmed sightings into analytics (concurrency, testing radius, heatmaps).
+
+> **Powered by TfL Open Data.** Contains OS data © Crown copyright and database rights.
+> Imagery is used under the Open Government Licence v2.0.
+
+## What we're detecting
+
+As of mid-2026 Waymo really is testing in London: heavily-modified **left-hand-drive white
+Jaguar I-PACEs** carrying a tall **central roof lidar dome** plus four corner sensor pods,
+mapping and running supervised-autonomous tests across ~100 sq miles / 20 boroughs (depot at
+Park Royal, NW10). The fleet is small (~tens scaling toward ~100 vehicles).
+
+The single visual cue that survives a 352×288 traffic-camera frame is the **roof dome**:
+
+- **DOME on the roof → Waymo**
+- **flat low roof BAR → Wayve / Uber** (the main false positive; Wayve also uses I-PACEs, so
+  the base car model is *not* a discriminator — only the roof hardware is)
+
+## The feed (verified live, 3 Jun 2026)
+
+- `GET https://api.tfl.gov.uk/Place/Type/JamCam` → **882 cameras** (779 available), each with
+  lat/lon + an S3 `imageUrl` (.jpg) and `videoUrl` (.mp4).
+- Image/clip host: `https://s3-eu-west-1.amazonaws.com/jamcams.tfl.gov.uk/<short_id>.{jpg,mp4}`
+  (`short_id` = camera id with the `JamCams_` prefix stripped).
+- **Each clip is H.264, 25 fps, ~11 s, ~277 frames, 352×288** — *not* a single snapshot. It's
+  the latest 11-second clip, refreshed roughly every 3–8 min per camera (staggered).
+- ETag / Last-Modified headers allow conditional GET, so unchanged clips cost nothing.
+
+## Honest scope
+
+This is a **"surface rare candidates for human confirmation"** system, not a live fleet
+tracker. Two hard limits, neither fixable by a better model:
+
+1. Each camera only gives ~11 s of footage every ~3 min, so most Waymo passes are never on
+   camera. "How many out at once" can only ever be a **lower bound** (or a modelled occupancy
+   estimate), never a census.
+2. At 352×288 the roof dome is ~5–15 px and only resolvable for near/mid-field vehicles. Recall
+   will be modest; a human gate buys precision. Expect possibly days between confirmable sightings.
+
+## Legal / privacy
+
+JamCam imagery is Open Government Licence v2 (commercial reuse permitted with the attribution
+above). The feeds are deliberately downsampled so number plates and faces are **not** legible —
+we log a *corporate fleet's* presence, never identifiable individuals, so UK-GDPR is not engaged.
+TfL explicitly endorses ML vehicle detection on this feed. We do not enrich sightings with any
+plate/driver-identifying data.
+
+## Status
+
+- [x] Data plane proven end-to-end against the live feed (`collector/data_plane.py`)
+- [ ] Training data acquired + WaymoNet fine-tuned
+- [ ] Video-clip inference runtime
+- [ ] Sighting feed: WhatsApp alerts + Leaflet map + confirm queue
+- [ ] Analytics (concurrency, alpha-shape footprint, KDE heatmap)

--- a/projects/waymowatch/collector/data_plane.py
+++ b/projects/waymowatch/collector/data_plane.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""WaymoWatch data plane.
+
+Pulls the TfL JamCam camera list, conditional-GETs each camera's latest ~11s video
+clip from S3 (skipping clips we've already seen via ETag), extracts frames at a
+chosen sample rate with OpenCV, and records everything in SQLite.
+
+This is the no-regrets foundation: it produces the frames WaymoNet trains on and,
+later, runs inference over. No detection happens here yet.
+
+Powered by TfL Open Data.
+"""
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import time
+import urllib.error
+import urllib.request
+
+import cv2
+
+JAMCAM_LIST_URL = "https://api.tfl.gov.uk/Place/Type/JamCam"
+CENTRAL_LONDON = (51.5074, -0.1278)  # Trafalgar Square
+BASE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_DB = os.path.join(BASE, "data", "waymo.db")
+DEFAULT_CLIPS = os.path.join(BASE, "data", "clips")
+DEFAULT_FRAMES = os.path.join(BASE, "data", "frames")
+UA = "Mozilla/5.0 (compatible; WaymoWatch/0.1; Powered by TfL Open Data)"
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, value TEXT);
+CREATE TABLE IF NOT EXISTS cameras (
+    id TEXT PRIMARY KEY, short_id TEXT, common_name TEXT, view TEXT,
+    lat REAL, lon REAL, available INTEGER, image_url TEXT, video_url TEXT,
+    last_seen TEXT
+);
+CREATE TABLE IF NOT EXISTS clips (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    camera_id TEXT REFERENCES cameras(id),
+    etag TEXT, last_modified TEXT, sha256 TEXT, bytes INTEGER,
+    fps REAL, n_frames INTEGER, width INTEGER, height INTEGER, duration REAL,
+    fetched_at TEXT, path TEXT,
+    UNIQUE(camera_id, etag)
+);
+CREATE TABLE IF NOT EXISTS frames (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    clip_id INTEGER REFERENCES clips(id),
+    camera_id TEXT, frame_idx INTEGER, t_sec REAL, path TEXT
+);
+-- analytics-grade tables, populated later by the detector + human review
+CREATE TABLE IF NOT EXISTS sightings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    clip_id INTEGER, frame_id INTEGER, camera_id TEXT, lat REAL, lon REAL,
+    captured_at TEXT, confidence REAL, crop_path TEXT,
+    status TEXT DEFAULT 'unconfirmed',  -- unconfirmed|waymo|wayve|reject
+    verifier TEXT, confirmed_at TEXT, dwell_group INTEGER, trajectory_id INTEGER
+);
+CREATE TABLE IF NOT EXISTS labels (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    frame_id INTEGER, crop_path TEXT, label TEXT, source TEXT, created_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_frames_camera ON frames(camera_id);
+CREATE INDEX IF NOT EXISTS idx_clips_camera ON clips(camera_id);
+CREATE INDEX IF NOT EXISTS idx_sightings_status ON sightings(status);
+"""
+
+
+def db_connect(path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    con = sqlite3.connect(path)
+    con.execute("PRAGMA journal_mode=WAL")
+    con.execute("PRAGMA busy_timeout=10000")
+    con.executescript(SCHEMA)
+    return con
+
+
+def http_get(url, etag=None, retries=3):
+    """Return (status, body, headers). status 304 => not modified (body None).
+
+    Retries transient connection failures with backoff (the feed occasionally
+    drops connections under load / behind the CDN).
+    """
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    if etag:
+        req.add_header("If-None-Match", etag)
+    last_err = None
+    for attempt in range(retries):
+        try:
+            with urllib.request.urlopen(req, timeout=40) as resp:
+                return resp.status, resp.read(), resp.headers
+        except urllib.error.HTTPError as e:
+            if e.code == 304:
+                return 304, None, e.headers
+            raise
+        except (urllib.error.URLError, ConnectionError, OSError) as e:
+            last_err = e
+            time.sleep(1.5 * (attempt + 1))
+    raise last_err
+
+
+def fetch_camera_list():
+    _, body, _ = http_get(JAMCAM_LIST_URL)
+    return json.loads(body)
+
+
+def props(cam):
+    return {p["key"]: p.get("value") for p in cam.get("additionalProperties", [])}
+
+
+def upsert_cameras(con, cams):
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    rows = []
+    for c in cams:
+        p = props(c)
+        img = p.get("imageUrl", "")
+        short = c["id"].replace("JamCams_", "")
+        rows.append((c["id"], short, c.get("commonName"), p.get("view"),
+                     c.get("lat"), c.get("lon"),
+                     1 if p.get("available") == "true" else 0,
+                     img, p.get("videoUrl"), now))
+    con.executemany(
+        """INSERT INTO cameras(id,short_id,common_name,view,lat,lon,available,image_url,video_url,last_seen)
+           VALUES(?,?,?,?,?,?,?,?,?,?)
+           ON CONFLICT(id) DO UPDATE SET available=excluded.available,
+             image_url=excluded.image_url, video_url=excluded.video_url, last_seen=excluded.last_seen""",
+        rows)
+    con.commit()
+    return len(rows)
+
+
+def select_cameras(cams, n, area):
+    avail = [c for c in cams if props(c).get("available") == "true" and props(c).get("videoUrl")]
+    if area == "central":
+        ay, ax = CENTRAL_LONDON
+        avail.sort(key=lambda c: (c["lat"] - ay) ** 2 + (c["lon"] - ax) ** 2)
+    return avail if n in (0, None) else avail[:n]
+
+
+def fetch_clip(con, cam, clips_dir):
+    """Conditional-GET a camera's clip. Returns clip row id, or None if unchanged."""
+    cid = cam["id"]
+    vid = props(cam).get("videoUrl")
+    last = con.execute(
+        "SELECT etag FROM clips WHERE camera_id=? ORDER BY id DESC LIMIT 1", (cid,)).fetchone()
+    etag = last[0] if last else None
+    status, body, headers = http_get(vid, etag=etag)
+    if status == 304 or not body:
+        return None, "unchanged"
+    new_etag = headers.get("ETag")
+    if new_etag and etag and new_etag == etag:
+        return None, "same-etag"
+    sha = hashlib.sha256(body).hexdigest()
+    dup = con.execute("SELECT id FROM clips WHERE camera_id=? AND sha256=?", (cid, sha)).fetchone()
+    if dup:
+        return None, "same-bytes"
+    short = cam["id"].replace("JamCams_", "")
+    os.makedirs(clips_dir, exist_ok=True)
+    path = os.path.join(clips_dir, f"{short}.{sha[:12]}.mp4")
+    with open(path, "wb") as f:
+        f.write(body)
+    cap = cv2.VideoCapture(path)
+    fps = cap.get(cv2.CAP_PROP_FPS) or 0.0
+    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    n = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    cap.release()
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    cur = con.execute(
+        """INSERT OR IGNORE INTO clips(camera_id,etag,last_modified,sha256,bytes,fps,n_frames,width,height,duration,fetched_at,path)
+           VALUES(?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (cid, new_etag, headers.get("Last-Modified"), sha, len(body), fps, n, w, h,
+         (n / fps if fps else 0.0), now, path))
+    con.commit()
+    return cur.lastrowid, "new"
+
+
+def extract_frames(con, clip_id, cam, sample_fps, frames_dir):
+    row = con.execute("SELECT path, fps FROM clips WHERE id=?", (clip_id,)).fetchone()
+    if not row:
+        return 0
+    path, fps = row
+    fps = fps or 25.0
+    step = max(1, round(fps / sample_fps))
+    short = cam["id"].replace("JamCams_", "")
+    out_dir = os.path.join(frames_dir, short, str(clip_id))
+    os.makedirs(out_dir, exist_ok=True)
+    cap = cv2.VideoCapture(path)
+    idx = saved = 0
+    rows = []
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        if idx % step == 0:
+            fp = os.path.join(out_dir, f"f{idx:04d}.jpg")
+            cv2.imwrite(fp, frame)
+            rows.append((clip_id, cam["id"], idx, idx / fps, fp))
+            saved += 1
+        idx += 1
+    cap.release()
+    con.executemany(
+        "INSERT INTO frames(clip_id,camera_id,frame_idx,t_sec,path) VALUES(?,?,?,?,?)", rows)
+    con.commit()
+    return saved
+
+
+def main():
+    ap = argparse.ArgumentParser(description="WaymoWatch data plane (Powered by TfL Open Data)")
+    ap.add_argument("--db", default=DEFAULT_DB)
+    ap.add_argument("--clips-dir", default=DEFAULT_CLIPS)
+    ap.add_argument("--frames-dir", default=DEFAULT_FRAMES)
+    ap.add_argument("--cameras", type=int, default=12, help="how many cameras (0 = all available)")
+    ap.add_argument("--area", choices=["central", "all"], default="central")
+    ap.add_argument("--sample-fps", type=float, default=5.0, help="frames/sec to extract per clip")
+    args = ap.parse_args()
+
+    t0 = time.time()
+    con = db_connect(args.db)
+    cams = fetch_camera_list()
+    upsert_cameras(con, cams)
+    chosen = select_cameras(cams, args.cameras, args.area)
+    print(f"cameras: {len(cams)} total, {sum(1 for c in cams if props(c).get('available')=='true')} available; "
+          f"processing {len(chosen)} ({args.area})")
+
+    stats = {"new": 0, "unchanged": 0, "same-bytes": 0, "same-etag": 0, "frames": 0, "errors": 0}
+    for c in chosen:
+        try:
+            clip_id, why = fetch_clip(con, c, args.clips_dir)
+            stats[why] = stats.get(why, 0) + 1
+            if clip_id:
+                got = extract_frames(con, clip_id, c, args.sample_fps, args.frames_dir)
+                stats["frames"] += got
+                print(f"  {c['id']:<22} {c.get('commonName','')[:28]:<28} clip#{clip_id} +{got} frames")
+            else:
+                print(f"  {c['id']:<22} {c.get('commonName','')[:28]:<28} ({why})")
+        except Exception as e:  # keep the sweep going
+            stats["errors"] += 1
+            print(f"  {c['id']:<22} ERROR {type(e).__name__}: {e}")
+
+    con.execute("INSERT OR REPLACE INTO kv(key,value) VALUES('last_sweep',?)",
+                (time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),))
+    con.commit()
+    print(f"\nsweep done in {time.time()-t0:.1f}s | "
+          + " ".join(f"{k}={v}" for k, v in stats.items()))
+    tot = con.execute("SELECT (SELECT COUNT(*) FROM clips),(SELECT COUNT(*) FROM frames)").fetchone()
+    print(f"db totals: clips={tot[0]} frames={tot[1]} -> {args.db}")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/waymowatch/collector/requirements.txt
+++ b/projects/waymowatch/collector/requirements.txt
@@ -1,0 +1,2 @@
+opencv-python-headless>=4.9
+numpy>=1.26

--- a/projects/waymowatch/dataset/copy_paste.py
+++ b/projects/waymowatch/dataset/copy_paste.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Copy-paste synthetic-positive engine + JamCam domain degradation.
+
+Core idea: real Waymo dome imagery is scarce, so we manufacture training positives
+by compositing real dome/vehicle crops onto real empty London JamCam backplates and
+degrading them to the 352x288 / JPEG domain the detector actually sees.
+
+This module also provides `simulate_at_scale`, used to sanity-check whether the roof
+dome is even resolvable at the pixel sizes a JamCam renders a vehicle.
+"""
+import cv2
+import numpy as np
+
+
+def jamcam_degrade(img, jpeg_q=38, blur=0.0):
+    """Push an image through the JamCam codec/optics signature: optional slight blur
+    then a low-quality JPEG round-trip (the feed is libavcodec-encoded ~CIF)."""
+    out = img
+    if blur > 0:
+        k = max(1, int(blur)) | 1
+        out = cv2.GaussianBlur(out, (k, k), 0)
+    enc = cv2.imencode(".jpg", out, [cv2.IMWRITE_JPEG_QUALITY, jpeg_q])[1]
+    return cv2.imdecode(enc, cv2.IMREAD_COLOR)
+
+
+def simulate_at_scale(crop, target_h, jpeg_q=35):
+    """Render a vehicle crop at the height (px) it would occupy in a JamCam frame,
+    with JPEG degradation. Returns the small image (not upscaled)."""
+    h, w = crop.shape[:2]
+    s = target_h / h
+    small = cv2.resize(crop, (max(1, int(w * s)), target_h), interpolation=cv2.INTER_AREA)
+    return jamcam_degrade(small, jpeg_q=jpeg_q)
+
+
+def feathered_alpha(h, w, feather=0.18):
+    """Soft elliptical alpha for blending a roughly-cropped patch."""
+    m = np.zeros((h, w), np.float32)
+    cv2.ellipse(m, (w // 2, h // 2), (int(w * 0.5) - 1, int(h * 0.5) - 1), 0, 0, 360, 1, -1)
+    k = max(1, int(min(h, w) * feather)) | 1
+    return cv2.GaussianBlur(m, (k, k), 0)
+
+
+def composite(backplate, patch, cx, cy, scale, alpha=None, brightness_match=True):
+    """Alpha-blend `patch` onto `backplate` centred at (cx,cy), scaled. Returns
+    (image, (x0,y0,w,h)) where the box is the pasted region (for a YOLO label)."""
+    ph, pw = patch.shape[:2]
+    nw, nh = max(2, int(pw * scale)), max(2, int(ph * scale))
+    patch = cv2.resize(patch, (nw, nh), interpolation=cv2.INTER_AREA)
+    a = cv2.resize(alpha, (nw, nh)) if alpha is not None else feathered_alpha(nh, nw)
+    x0, y0 = int(cx - nw / 2), int(cy - nh / 2)
+    H, W = backplate.shape[:2]
+    xs, ys = max(0, x0), max(0, y0)
+    xe, ye = min(W, x0 + nw), min(H, y0 + nh)
+    if xe <= xs or ye <= ys:
+        return backplate, None
+    px0, py0 = xs - x0, ys - y0
+    sub = patch[py0:py0 + (ye - ys), px0:px0 + (xe - xs)].astype(np.float32)
+    asub = a[py0:py0 + (ye - ys), px0:px0 + (xe - xs)][:, :, None]
+    bg = backplate[ys:ye, xs:xe].astype(np.float32)
+    if brightness_match:
+        bm, sm = bg.mean(), sub.mean() + 1e-6
+        sub = np.clip(sub * (bm / sm), 0, 255)
+    out = backplate.copy()
+    out[ys:ye, xs:xe] = (asub * sub + (1 - asub) * bg).astype(np.uint8)
+    return out, (xs, ys, xe - xs, ye - ys)
+
+
+def _label(img, text):
+    cv2.rectangle(img, (0, 0), (8 + 9 * len(text), 22), (0, 0, 0), -1)
+    cv2.putText(img, text, (4, 16), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (0, 255, 0), 1)
+    return img
+
+
+if __name__ == "__main__":
+    # Resolvability experiment: render the real Miami Waymo (05) at JamCam vehicle scales.
+    import os
+    BASE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    src = cv2.imread(os.path.join(BASE, "data/sources/waymo/05_Waymo_Driverless_Vehicle_Brickell_Miami_April_.jpg"))
+    car = src[150:620, 180:1130]  # whole I-PACE incl. roof dome (px in the 1280x960 source)
+    cv2.imwrite(os.path.join(BASE, "data/sources/waymo05_car.jpg"), car)
+    cv2.imwrite(os.path.join(BASE, "data/sources/waymo05_dome.jpg"), src[150:300, 500:760])
+    panels, ZOOM = [], 8
+    for h, tag in [(18, "18px far"), (30, "30px mid"), (48, "48px near"), (80, "80px close")]:
+        small = simulate_at_scale(car, h)
+        big = cv2.resize(small, (small.shape[1] * ZOOM, small.shape[0] * ZOOM), interpolation=cv2.INTER_NEAREST)
+        canvas = np.full((80 * ZOOM, max(big.shape[1], 120), 3), 35, np.uint8)
+        canvas[:big.shape[0], :big.shape[1]] = big
+        panels.append(_label(canvas, tag))
+    montage = np.hstack([cv2.copyMakeBorder(p, 2, 2, 2, 2, cv2.BORDER_CONSTANT, value=(80, 80, 80)) for p in panels])
+    out = os.path.join(BASE, "data/sources/dome_scale_test.jpg")
+    cv2.imwrite(out, montage)
+    print("wrote", out, montage.shape, "(8x nearest-neighbour zoom of JamCam-scale renders)")

--- a/projects/waymowatch/dataset/fetch_sources.py
+++ b/projects/waymowatch/dataset/fetch_sources.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Fetch CC/PD-licensed Waymo (and Jaguar I-PACE) imagery from Wikimedia Commons,
+record per-image licence/attribution to a manifest, and build a labelled contact
+sheet so we can pick clean roof-dome crops for the copy-paste synthetic-positive engine.
+
+Wikimedia Commons images are reusable (CC/PD) with attribution — safe to train a
+shippable model on, unlike the Waymo Open Dataset / Getty.
+"""
+import glob
+import json
+import os
+import re
+import urllib.parse
+import urllib.request
+
+import cv2
+import numpy as np
+
+BASE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OUT = os.path.join(BASE, "data", "sources", "waymo")
+API = "https://commons.wikimedia.org/w/api.php"
+UA = "WaymoWatch/0.1 (autonomous-vehicle spotting research; https://hjd.ai)"
+CATEGORIES = ["Category:Waymo", "Category:Waymo vehicles", "Category:Jaguar I-Pace"]
+MAX_IMAGES = 28
+
+
+def api(params):
+    params = {**params, "format": "json"}
+    url = API + "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=40) as r:
+        return json.load(r)
+
+
+def strip_html(s):
+    return re.sub(r"<[^>]+>", "", s or "").strip()
+
+
+def gather():
+    manifest, seen = [], set()
+    for cat in CATEGORIES:
+        try:
+            data = api({"action": "query", "generator": "categorymembers",
+                        "gcmtitle": cat, "gcmtype": "file", "gcmlimit": "40",
+                        "prop": "imageinfo", "iiprop": "url|mime|extmetadata",
+                        "iiurlwidth": "1024"})
+        except Exception as e:
+            print(f"  category {cat}: ERROR {e}")
+            continue
+        for page in data.get("query", {}).get("pages", {}).values():
+            ii = (page.get("imageinfo") or [{}])[0]
+            if not ii.get("mime", "").startswith("image/"):
+                continue
+            title = page["title"]
+            if title in seen:
+                continue
+            seen.add(title)
+            em = ii.get("extmetadata", {})
+            manifest.append({
+                "title": title,
+                "url": ii.get("thumburl") or ii.get("url"),
+                "license": strip_html(em.get("LicenseShortName", {}).get("value", "?")),
+                "artist": strip_html(em.get("Artist", {}).get("value", "?"))[:80],
+                "descurl": ii.get("descriptionurl"),
+                "category": cat,
+            })
+    return manifest[:MAX_IMAGES]
+
+
+def download(manifest):
+    os.makedirs(OUT, exist_ok=True)
+    ok = 0
+    for i, m in enumerate(manifest):
+        if not m["url"]:
+            continue
+        ext = os.path.splitext(urllib.parse.urlparse(m["url"]).path)[1].lower() or ".jpg"
+        if ext not in (".jpg", ".jpeg", ".png", ".webp"):
+            ext = ".jpg"
+        safe = re.sub(r"[^A-Za-z0-9]+", "_", m["title"].replace("File:", ""))[:46]
+        fp = os.path.join(OUT, f"{i:02d}_{safe}{ext}")
+        try:
+            req = urllib.request.Request(m["url"], headers={"User-Agent": UA})
+            with urllib.request.urlopen(req, timeout=60) as r, open(fp, "wb") as f:
+                f.write(r.read())
+            m["path"], m["idx"] = fp, i
+            ok += 1
+        except Exception as e:
+            m["error"] = str(e)
+    json.dump(manifest, open(os.path.join(OUT, "manifest.json"), "w"), indent=2)
+    return ok
+
+
+def contact_sheet(cols=4, cell=260):
+    files = sorted(f for ext in ("*.jpg", "*.jpeg", "*.png", "*.webp")
+                   for f in glob.glob(os.path.join(OUT, ext)))
+    cells = []
+    for f in files:
+        im = cv2.imread(f)
+        if im is None:
+            continue
+        h, w = im.shape[:2]
+        im = cv2.resize(im, (cell, max(1, int(h * cell / w))))
+        canvas = np.full((cell, cell, 3), 35, np.uint8)
+        hh = min(im.shape[0], cell)
+        canvas[:hh] = im[:hh]
+        tag = os.path.basename(f).split("_")[0]
+        cv2.rectangle(canvas, (0, 0), (40, 24), (0, 0, 0), -1)
+        cv2.putText(canvas, tag, (4, 18), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 0), 2)
+        cells.append((tag, f, canvas))
+    if not cells:
+        print("no images to montage")
+        return
+    rows = []
+    for r in range(0, len(cells), cols):
+        row = [c[2] for c in cells[r:r + cols]]
+        while len(row) < cols:
+            row.append(np.full((cell, cell, 3), 35, np.uint8))
+        rows.append(np.hstack(row))
+    sheet = np.vstack(rows)
+    out = os.path.join(BASE, "data", "sources", "waymo_contact_sheet.jpg")
+    cv2.imwrite(out, sheet)
+    print(f"contact sheet: {out}  ({sheet.shape[1]}x{sheet.shape[0]}, {len(cells)} imgs)")
+    print("index -> file | licence:")
+    man = {m.get("idx"): m for m in json.load(open(os.path.join(OUT, "manifest.json")))}
+    for tag, f, _ in cells:
+        m = man.get(int(tag), {})
+        print(f"  {tag}  {os.path.basename(f)[:40]:<40} {m.get('license','?')}")
+
+
+if __name__ == "__main__":
+    man = gather()
+    n = download(man)
+    print(f"downloaded {n}/{len(man)} images to {OUT}")
+    contact_sheet()

--- a/projects/waymowatch/dataset/make_synthetic.py
+++ b/projects/waymowatch/dataset/make_synthetic.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Synthetic-positive generator for WaymoNet.
+
+Real in-feed Waymos are too rare to wait for, so we manufacture training positives:
+detect real vehicles in real London JamCam backplates, paste a real Waymo roof-dome
+onto resolvable-size roofs, brightness-match + feather, re-degrade to the JamCam JPEG
+domain, and emit a YOLO label (class 0 = waymo, box = the host vehicle).
+
+Only vehicles >= MIN_H px tall are used, because the dome is only resolvable when the
+car is near/mid field (the 45px finding from dome_scale_test).
+"""
+import glob
+import os
+import random
+import sys
+
+import cv2
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from copy_paste import composite, feathered_alpha, jamcam_degrade  # noqa: E402
+
+BASE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FRAMES = os.path.join(BASE, "data", "frames")
+OUT_IMG = os.path.join(BASE, "data", "synthetic", "images")
+OUT_LBL = os.path.join(BASE, "data", "synthetic", "labels")
+DOME_SRC = os.path.join(BASE, "data/sources/waymo/05_Waymo_Driverless_Vehicle_Brickell_Miami_April_.jpg")
+DOME_BBOX = (553, 150, 685, 245)  # (x1,y1,x2,y2) the lidar dome+mount in the source
+MIN_H = 30          # min host-vehicle bbox height (px) — dome must be resolvable
+MAX_AR = 1.9        # max width/height — excludes long buses/lorries; Waymos are cars
+VEHICLE_CLS = {2}   # COCO car only (Waymo = car-sized Jaguar I-PACE, not bus/lorry)
+MAX_POS = 80
+SEED = 1234
+
+
+def load_dome():
+    src = cv2.imread(DOME_SRC)
+    x1, y1, x2, y2 = DOME_BBOX
+    dome = src[y1:y2, x1:x2]
+    h, w = dome.shape[:2]
+    # alpha: keep the central dome, fade edges; bias toward the darker dome pixels
+    alpha = feathered_alpha(h, w, feather=0.16)
+    gray = cv2.cvtColor(dome, cv2.COLOR_BGR2GRAY).astype(np.float32) / 255.0
+    darkness = np.clip(1.0 - gray * 1.1, 0, 1)  # dome is dark vs bright sky/roof
+    alpha = np.clip(alpha * darkness ** 1.4, 0, 1)  # concentrate on the dark dome, less boxy
+    return dome, alpha
+
+
+def synth_one(frame, boxes, dome, dome_a):
+    """Paste a dome on the largest resolvable vehicle; return (img, yolo_line) or None."""
+    cand = [b for b in boxes if (b[3] - b[1]) >= MIN_H
+            and (b[2] - b[0]) / max(1, b[3] - b[1]) <= MAX_AR]
+    if not cand:
+        return None
+    x1, y1, x2, y2 = max(cand, key=lambda b: (b[2] - b[0]) * (b[3] - b[1]))
+    vw, vh = x2 - x1, y2 - y1
+    # dome width ~ 0.34 of car width; place at roof (top-centre of the vehicle box)
+    target_w = max(8, int(vw * 0.34))
+    scale = target_w / dome.shape[1]
+    cx = x1 + vw * 0.5 + random.uniform(-0.05, 0.05) * vw
+    cy = y1 + dome.shape[0] * scale * 0.45 + vh * 0.04  # sit just on the roofline
+    out, box = composite(frame, dome, cx, cy, scale, alpha=dome_a, brightness_match=True)
+    if box is None:
+        return None
+    out = jamcam_degrade(out, jpeg_q=random.randint(32, 46))
+    H, W = out.shape[:2]
+    cxn, cyn = (x1 + x2) / 2 / W, (y1 + y2) / 2 / H
+    wn, hn = vw / W, vh / H
+    return out, f"0 {cxn:.6f} {cyn:.6f} {wn:.6f} {hn:.6f}", (x1, y1, x2, y2)
+
+
+def main():
+    random.seed(SEED)
+    os.makedirs(OUT_IMG, exist_ok=True)
+    os.makedirs(OUT_LBL, exist_ok=True)
+    from ultralytics import YOLO
+    det = YOLO("yolo11n.pt")
+    dome, dome_a = load_dome()
+    frames = sorted(glob.glob(os.path.join(FRAMES, "**", "*.jpg"), recursive=True))
+    random.shuffle(frames)
+    made, crops = 0, []
+    for fp in frames:
+        if made >= MAX_POS:
+            break
+        img = cv2.imread(fp)
+        if img is None:
+            continue
+        r = det.predict(img, conf=0.30, verbose=False, imgsz=352)[0]
+        boxes = [tuple(map(int, b.xyxy[0].tolist())) for b in r.boxes
+                 if int(b.cls[0]) in VEHICLE_CLS]
+        res = synth_one(img, boxes, dome, dome_a)
+        if not res:
+            continue
+        out, line, (x1, y1, x2, y2) = res
+        name = f"syn_{made:03d}"
+        cv2.imwrite(os.path.join(OUT_IMG, name + ".jpg"), out)
+        open(os.path.join(OUT_LBL, name + ".txt"), "w").write(line + "\n")
+        # zoomed crop of the host vehicle for the inspection sheet
+        pad = 6
+        crop = out[max(0, y1 - pad):y2 + pad, max(0, x1 - pad):x2 + pad]
+        if crop.size:
+            crops.append(cv2.resize(crop, (160, 160), interpolation=cv2.INTER_NEAREST))
+        made += 1
+    print(f"generated {made} synthetic positives -> {OUT_IMG}")
+    # contact sheet of the pasted vehicles (4x zoom)
+    if crops:
+        cols = 6
+        while len(crops) % cols:
+            crops.append(np.full((160, 160, 3), 35, np.uint8))
+        rows = [np.hstack(crops[i:i + cols]) for i in range(0, len(crops), cols)]
+        sheet = np.vstack(rows)
+        out = os.path.join(BASE, "data/synthetic/synthetic_contact_sheet.jpg")
+        cv2.imwrite(out, sheet)
+        print(f"contact sheet -> {out} {sheet.shape}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
New project to spot/log Waymo's London test fleet (roof-lidar Jaguar I-PACEs) from TfL JamCam video clips via a purpose-trained detector (WaymoNet).

This slice proves the two hardest unknowns are tractable (verified live, CPU-only):
- Collector pulls all 882 JamCams, conditional-GETs ~11s/25fps/352x288 clips, extracts sampled frames to SQLite (637 real London frames banked).
- Copy-paste synthetic-positive engine: detect cars in real London backplates, paste a real Waymo dome on resolvable-size roofs, degrade to the JamCam JPEG domain, emit YOLO labels (80 positives generated).
- Quantified the recall ceiling: the dome is only resolvable when the host vehicle is >=45px tall (per-clip detection + size gate).

No off-the-shelf dataset/model fits (ego-viewpoint or non-commercial), so data is bespoke: our own OGL JamCam frames + the copy-paste engine.

Plan + decisions tracked in repo-root tasks/todo.md. Powered by TfL Open Data.