### PR TITLE
All-In: fix the five P0 correctness bugs from the reliability audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ axiom-bootstrap.tar.gz
 # Build output / bundler artifacts
 dist/
 
+# Wrangler local dev state (miniflare KV/cache)
+.wrangler/
+
 # ML run outputs (e.g. YOLO runs/detect)
 runs/
 

--- a/projects/all-in/scripts/test-earnings-night-tz.mjs
+++ b/projects/all-in/scripts/test-earnings-night-tz.mjs
@@ -1,0 +1,43 @@
+// Earnings-night arming check (P0.2 regression). Replicates isEarningsNight()'s
+// date handling frozen at 17:00 ET on EARNINGS_DATE (aftermarket window) and
+// verifies the viewer's timezone cannot shift the calendar day. Run it from a
+// UK/EU/Asia TZ — the old parse (dayjs(d).tz(EST)) failed for anyone at/east of
+// UTC; the fixed parse (dayjs.tz(d, EST)) must arm everywhere:
+//   TZ=Europe/London node scripts/test-earnings-night-tz.mjs
+// Rerun after updating EARNINGS_DATE each quarter to confirm live mode will arm.
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+import timezone from 'dayjs/plugin/timezone.js';
+import { EST, EARNINGS_DATE, EARNINGS_TIME } from '../src/utils/config.js';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+if (EARNINGS_TIME !== 'aftermarket') {
+  console.log(`EARNINGS_TIME is '${EARNINGS_TIME}' — this check freezes at 17:00 ET and only covers aftermarket.`);
+}
+
+const RealDate = Date;
+const frozen = new RealDate(`${EARNINGS_DATE}T17:00:00-04:00`).getTime();
+global.Date = class extends RealDate {
+  constructor(...a) { if (a.length) { super(...a); } else { super(frozen); } }
+  static now() { return frozen; }
+};
+
+const now = dayjs().tz(EST);
+const oldParse = dayjs(EARNINGS_DATE).tz(EST);
+const newParse = dayjs.tz(EARNINGS_DATE, EST);
+
+const armed = (day) => now.isSame(day, 'day') && now.hour() >= 16 && now.hour() < 23;
+
+console.log(`viewer TZ=${process.env.TZ || '(system)'}, now=${now.format('YYYY-MM-DD HH:mm')} ET`);
+console.log(`old parse → earningsDay=${oldParse.format('YYYY-MM-DD')} ET, armed=${armed(oldParse)}`);
+console.log(`new parse → earningsDay=${newParse.format('YYYY-MM-DD')} ET, armed=${armed(newParse)}`);
+
+global.Date = RealDate;
+if (armed(newParse)) {
+  console.log('PASS  earnings night arms with the EST-parsed date');
+} else {
+  console.log('FAIL  earnings night did not arm');
+  process.exit(1);
+}

--- a/projects/all-in/scripts/test-market-state.mjs
+++ b/projects/all-in/scripts/test-market-state.mjs
@@ -1,0 +1,81 @@
+// Market-state classification matrix (P0.1 regression) — drives the REAL
+// src/utils/marketState.js (bundled via esbuild, as Vite would resolve it) with a
+// frozen wall-clock and mocked Alpaca clock data. Covers the post-market-vs-
+// holiday ambiguity: after the 4pm close next_open is always the NEXT day, which
+// must not flag an ordinary evening as a holiday (that froze post-market prices).
+//   node scripts/test-market-state.mjs
+import { build } from 'esbuild';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const outDir = await mkdtemp(join(tmpdir(), 'ms-test-'));
+const bundle = join(outDir, 'marketState.bundle.mjs');
+await build({
+  entryPoints: [join(projectRoot, 'src/utils/marketState.js')],
+  bundle: true,
+  format: 'esm',
+  outfile: bundle,
+  logLevel: 'error'
+});
+const { getMarketState, MarketState } = await import(pathToFileURL(bundle).href);
+
+const RealDate = Date;
+function freezeAt(iso) {
+  const t = new RealDate(iso).getTime();
+  global.Date = class extends RealDate {
+    constructor(...a) { if (a.length) { super(...a); } else { super(t); } }
+    static now() { return t; }
+  };
+}
+
+const cases = [
+  // [label, frozen now, clockData, expected state, expected isHoliday]
+  ['normal Mon 17:30 ET → POST_MARKET (was CLOSED pre-fix)',
+    '2026-07-06T17:30:00-04:00',
+    { isOpen: false, nextOpen: '2026-07-07T09:30:00-04:00', nextClose: '2026-07-07T16:00:00-04:00' },
+    MarketState.POST_MARKET, false],
+  ['normal Mon 08:00 ET → PRE_MARKET',
+    '2026-07-06T08:00:00-04:00',
+    { isOpen: false, nextOpen: '2026-07-06T09:30:00-04:00', nextClose: '2026-07-06T16:00:00-04:00' },
+    MarketState.PRE_MARKET, false],
+  ['normal Mon 10:30 ET, isOpen → OPEN',
+    '2026-07-06T10:30:00-04:00',
+    { isOpen: true, nextOpen: '2026-07-07T09:30:00-04:00', nextClose: '2026-07-06T16:00:00-04:00' },
+    MarketState.OPEN, false],
+  ['normal Mon 21:30 ET → CLOSED',
+    '2026-07-06T21:30:00-04:00',
+    { isOpen: false, nextOpen: '2026-07-07T09:30:00-04:00', nextClose: '2026-07-07T16:00:00-04:00' },
+    MarketState.CLOSED, false],
+  ['holiday (Thanksgiving Thu) 08:00 ET → CLOSED, isHoliday',
+    '2026-11-26T08:00:00-05:00',
+    { isOpen: false, nextOpen: '2026-11-27T09:30:00-05:00', nextClose: '2026-11-27T13:00:00-05:00' },
+    MarketState.CLOSED, true],
+  ['holiday 12:00 ET → CLOSED (midday falls through no branch)',
+    '2026-11-26T12:00:00-05:00',
+    { isOpen: false, nextOpen: '2026-11-27T09:30:00-05:00', nextClose: '2026-11-27T13:00:00-05:00' },
+    MarketState.CLOSED, false],
+  ['holiday 17:00 ET → POST_MARKET (documented trade-off; today-row guarded by tradingDay)',
+    '2026-11-26T17:00:00-05:00',
+    { isOpen: false, nextOpen: '2026-11-27T09:30:00-05:00', nextClose: '2026-11-27T13:00:00-05:00' },
+    MarketState.POST_MARKET, false],
+  ['weekend Sat 12:00 ET → CLOSED',
+    '2026-07-04T12:00:00-04:00',
+    { isOpen: false, nextOpen: '2026-07-06T09:30:00-04:00', nextClose: '2026-07-06T16:00:00-04:00' },
+    MarketState.CLOSED, false],
+];
+
+let failed = 0;
+for (const [label, nowIso, clock, wantState, wantHoliday] of cases) {
+  freezeAt(nowIso);
+  const r = getMarketState(clock);
+  const ok = r.state === wantState && r.isHoliday === wantHoliday;
+  if (!ok) failed++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}` +
+    (ok ? '' : `  [got state=${r.state} isHoliday=${r.isHoliday}, want ${wantState}/${wantHoliday}]`));
+}
+global.Date = RealDate;
+await rm(outDir, { recursive: true, force: true });
+process.exit(failed ? 1 : 0);

--- a/projects/all-in/src/components/EarningsControlCentre.jsx
+++ b/projects/all-in/src/components/EarningsControlCentre.jsx
@@ -30,7 +30,10 @@ function isEarningsNight(clockData) {
   if (!CONFIG.earningsDate) return false;
 
   const now = dayjs().tz(EST);
-  const earningsDay = dayjs(CONFIG.earningsDate).tz(EST);
+  // Parse the date IN EST — dayjs(date).tz(EST) parses at the viewer's local
+  // midnight then converts, which shifts the calendar day for anyone at/east of
+  // UTC (a UK viewer would never see earnings night arm).
+  const earningsDay = dayjs.tz(CONFIG.earningsDate, EST);
 
   // Must be same calendar day
   if (!now.isSame(earningsDay, 'day')) return false;

--- a/projects/all-in/src/components/StockTracker.jsx
+++ b/projects/all-in/src/components/StockTracker.jsx
@@ -33,6 +33,9 @@ export default function StockTracker() {
     return initialState.isRegularHours ? '1D' : '6M';
   });
   const [quote, setQuote] = useState(null);
+  // Wall-clock of the last price that actually landed (fetch, WS tick, poll,
+  // settle read) — NOT render time, so a frozen price shows its true age.
+  const [lastUpdatedAt, setLastUpdatedAt] = useState(null);
   const [loading, setLoading] = useState(true);
   const [priceFlash, setPriceFlash] = useState(null);
   const [sortConfig, setSortConfig] = useState({ key: 'date', direction: 'desc' });
@@ -195,6 +198,7 @@ export default function StockTracker() {
           sharesOutstanding: priceData.sharesOutstanding,
           forwardPE: priceData.forwardPE
         });
+        setLastUpdatedAt(Date.now());
 
         if (marketState.usingApi) {
           console.log(`Market: ${marketState.state.toUpperCase()} | ${symbol}: $${priceData.currentPrice.toFixed(2)}${priceData.extendedHoursPrice ? ` | Extended: $${priceData.extendedHoursPrice.toFixed(2)}` : ''}`);
@@ -474,6 +478,7 @@ export default function StockTracker() {
         if (v == null) return;
 
         setSettlingValue(v);
+        setLastUpdatedAt(Date.now());
         const reads = [...settleReadingsRef.current, v];
         settleReadingsRef.current = reads;
 
@@ -517,6 +522,7 @@ export default function StockTracker() {
     setWeeklyData([]);
     setMonthlyData([]);
     setQuote(null);
+    setLastUpdatedAt(null);
 
     // Reset the close-settle machine for the new ticker, then re-derive its phase.
     stopSettlePoll();
@@ -697,6 +703,7 @@ export default function StockTracker() {
                   l: Math.min(prev.l || newPrice, newPrice)
                 };
               });
+              setLastUpdatedAt(Date.now());
               setPriceFlash(null);
               requestAnimationFrame(() => setPriceFlash(direction));
             }
@@ -849,6 +856,7 @@ export default function StockTracker() {
               extendedHoursType: priceData.extendedHoursType
             };
           });
+          setLastUpdatedAt(Date.now());
 
           console.log(`Market: ${currentState.state.toUpperCase()} | ${ticker}: $${priceData.currentPrice.toFixed(2)} | Extended: $${priceData.extendedHoursPrice.toFixed(2)}`);
         }
@@ -890,6 +898,7 @@ export default function StockTracker() {
               volume: priceData.volume || prev.volume
             };
           });
+          setLastUpdatedAt(Date.now());
         }
       } catch (error) {
         console.error('Fallback poll error:', error);
@@ -975,7 +984,10 @@ export default function StockTracker() {
             volume: quote?.volume || dataWithToday[todayIndex].volume,
           };
         }
-      } else {
+      } else if (quote?.tradingDay === todayEST) {
+        // tradingDay guard: on a holiday evening the state reads POST_MARKET (the
+        // Alpaca clock can't distinguish it from a normal evening) but Yahoo's last
+        // intraday bar is still the previous trading day — don't invent a today row.
         dataWithToday.push({
           date: todayEST,
           open: quote?.o ?? currentPrice,
@@ -1198,7 +1210,7 @@ export default function StockTracker() {
         </div>
 
         <div className="timestamp">
-          Last updated: {dayjs().format('HH:mm MMM D.')}
+          Last updated: {lastUpdatedAt ? dayjs(lastUpdatedAt).format('HH:mm MMM D.') : '—'}
           <span style={{ marginLeft: '12px', opacity: 0.7 }}>
             Market: {currentMarketState.isRegularHours ? 'Open' : 'Closed'}
           </span>

--- a/projects/all-in/src/hooks/useEarningsData.js
+++ b/projects/all-in/src/hooks/useEarningsData.js
@@ -92,8 +92,11 @@ export function useEarningsData(ticker, options = {}) {
         error: null
       }));
 
-      // If we got a racing result with pending sources, schedule a merge fetch
-      if (mode === 'race' && result.pendingSources?.length > 0 && result.allResults > 1) {
+      // A live race returns a single unvalidated source — follow up with a merge
+      // so the cross-validated record replaces it. Usually a cheap hit: the worker
+      // background-merges the race losers into KV and serves that when fresh
+      // (result.mode === 'kv'), which needs no follow-up.
+      if (mode === 'race' && result.mode === 'race') {
         setTimeout(() => fetchEarnings('merge'), 3000);
       }
 

--- a/projects/all-in/src/utils/marketState.js
+++ b/projects/all-in/src/utils/marketState.js
@@ -65,11 +65,15 @@ export const getMarketState = (clockData = null) => {
   // Use Alpaca clock data for accurate market status
   const { isOpen, nextOpen, nextClose } = clockData;
 
-  // Determine if today is a holiday:
-  // It's a weekday, market not open, and next open is not today
+  // Determine if today is a holiday: weekday, market not open, next open not today.
+  // Only decidable BEFORE the open — after the 4pm close next_open is always the
+  // next trading day, which would flag every ordinary evening as a holiday and
+  // force POST_MARKET to CLOSED. Trade-off: a holiday evening (16:00–20:00) reads
+  // POST_MARKET; the today-row guards against phantom rows via quote.tradingDay.
   const todayStr = now.format('YYYY-MM-DD');
   const nextOpenStr = nextOpen ? dayjs(nextOpen).tz(EST).format('YYYY-MM-DD') : null;
-  const isHoliday = !local.isWeekend && !isOpen && nextOpenStr !== todayStr;
+  const isBeforeOpen = local.timeInMinutes < MARKET_OPEN;
+  const isHoliday = !local.isWeekend && !isOpen && isBeforeOpen && nextOpenStr !== todayStr;
 
   let state;
 

--- a/projects/all-in/worker.js
+++ b/projects/all-in/worker.js
@@ -1298,16 +1298,25 @@ export default {
         const mode = url.searchParams.get('mode') || 'race';
         const ALPHAVANTAGE_KEY = env.ALPHA_VANTAGE_KEY_ENV;
 
-        // Check KV first for manually-pushed or recently-merged data
+        // Check KV first for manually-pushed or recently-merged data.
+        // Manual data always wins. A recently-merged record is served too — this is
+        // what surfaces the background cross-validation: poll N races (single
+        // source), the losers merge into KV via waitUntil, and poll N+1 gets the
+        // validated record. The freshness window keeps a race running roughly once
+        // a minute so the record can't go stale on earnings night.
+        const KV_FRESH_MS = 60 * 1000;
         if (env.EARNINGS_STORE) {
-          const latestKey = await env.EARNINGS_STORE.get(`earnings:${symbol}:latest`);
-          if (latestKey) {
-            const stored = await env.EARNINGS_STORE.get(latestKey, { type: 'json' });
-            if (stored && stored.manual) {
-              // Manual data takes priority - serve it immediately
+          try {
+            const latestKey = await env.EARNINGS_STORE.get(`earnings:${symbol}:latest`);
+            const stored = latestKey
+              ? await env.EARNINGS_STORE.get(latestKey, { type: 'json' })
+              : null;
+            const isFresh = stored?.lastUpdated &&
+              (Date.now() - Date.parse(stored.lastUpdated)) < KV_FRESH_MS;
+            if (stored && (stored.manual || isFresh)) {
               return new Response(JSON.stringify({
                 mode: 'kv',
-                source: 'manual',
+                source: stored.manual ? 'manual' : 'merged',
                 data: stored,
                 confidence: stored.confidence || 'single',
                 discrepancies: stored.discrepancies || []
@@ -1315,6 +1324,9 @@ export default {
                 headers: { ...corsHeaders, 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
               });
             }
+          } catch (e) {
+            // Corrupt KV blob must not 500 the endpoint — fall through to live fetch
+            console.error('earnings KV read failed, falling through:', e.message);
           }
         }
 
@@ -1483,8 +1495,9 @@ export default {
 
         // Build source array - Calendar first (fastest for fresh earnings), then history + EDGAR
         // Note: FMP v3 endpoints are deprecated (legacy), removed
+        const calendarPromise = fetchFinnhubCalendar();
         const sources = [
-          fetchFinnhubCalendar(),
+          calendarPromise,
           fetchFinnhub(),
           fetchEdgar()
         ];
@@ -1495,9 +1508,19 @@ export default {
         }
 
         if (mode === 'race') {
-          // True race: return first successful result immediately
+          // Biased race: the calendar source gets a short head start. It is the
+          // only source pinned to a freshly-released quarter (7-day actuals
+          // window) and carries both EPS and revenue — right after a release the
+          // other sources can still hold LAST quarter and must not win on
+          // latency. If the calendar errors ("no actuals yet") the head start
+          // costs nothing and we fall through to a true race.
           try {
-            const first = await Promise.any(
+            const CALENDAR_HEAD_START_MS = 1500;
+            const calendarFirst = await Promise.race([
+              calendarPromise.then(r => (r.error || !r.data) ? null : r),
+              new Promise(resolve => setTimeout(() => resolve(null), CALENDAR_HEAD_START_MS))
+            ]);
+            const first = calendarFirst || await Promise.any(
               sources.map(s => s.then(r => {
                 if (r.error || !r.data) throw r;
                 return r;

--- a/tasks/all-in-reliability-audit.md
+++ b/tasks/all-in-reliability-audit.md
@@ -1,0 +1,224 @@
+# All-In Reliability Audit — 2 July 2026
+
+Full-stack audit of the All-In stock tracker for data reliability, uptime, and update speed.
+Three parallel deep-dives: Cloudflare Worker, frontend real-time data layer, earnings/news pipelines.
+~45 findings consolidated below, prioritised. File:line refs verified by the auditing agents.
+
+## Status — 4 July 2026: P0.1–P0.5 FIXED (this branch), plus P2.14 opportunistically
+
+Implementation notes (decisions that differ from or refine the fix sketches below):
+- **P0.1**: holiday detection now gated to before-the-open. Known trade-off: a holiday
+  *evening* (16:00–20:00 ET) classifies POST_MARKET; the synthetic today-row is guarded
+  against this by requiring `quote.tradingDay === today` (Yahoo's last intraday bar stays on
+  the previous trading day on holidays, so no phantom row). `isHoliday` has no consumers
+  outside the state derivation, so narrowing it is safe.
+- **P0.2**: `dayjs.tz(CONFIG.earningsDate, EST)`. The Finnhub-calendar-derived date (the
+  "Related (H)" hardening) is NOT done — still a P1 follow-up.
+- **P0.3**: worker now serves the background-merged KV record when `lastUpdated` < 60s old
+  (manual still always wins), so poll N races and poll N+1 gets the validated record; the
+  frontend's dead `pendingSources` branch replaced with a merge follow-up keyed on
+  `result.mode === 'race'`. Side benefit: on earnings night most 5s polls become KV hits,
+  cutting upstream quota burn (helps P1.3). The KV read is try/caught (fixes P2.14).
+- **P0.4**: implemented as a *biased race* — finnhub-calendar gets a 1.5s head start
+  (`Promise.race` against a timer, then `Promise.any` fallback). It is the only source pinned
+  to a freshly-released quarter and carries both metrics. Chosen over an expected-window
+  quarter check because the worker has no source of truth for the window. Costs nothing when
+  the calendar errors fast ("no actuals yet"), and race mode is only used on earnings night.
+- **P0.5**: real `lastUpdatedAt` stamped at every price-landing point (fetchStockData, WS
+  onmessage, fallback poll, extended-hours poll, settle reads), reset on ticker change,
+  rendered instead of wall-clock; shows `—` until the first price lands.
+- **Regression scripts** (permanent, in `projects/all-in/scripts/`):
+  `test-market-state.mjs` (8-case state matrix incl. the holiday trade-off) and
+  `test-earnings-night-tz.mjs` (arming check from any TZ; rerun each quarter after updating
+  EARNINGS_DATE). Verified passing; `npm run build` clean; worker validated via
+  `wrangler deploy --dry-run` + local miniflare probe of `/earnings/unified/TSLA` (race mode
+  returned live EDGAR data through the new biased-race path).
+- **Deploy note**: worker changes need `npm run deploy:worker` after merge; frontend
+  auto-deploys from main via Pages.
+- **Not started**: P1.1–P1.8, P2 (except 14).
+
+**Verdict:** structurally sound (good error isolation, abort handling, partial-failure tolerance) but
+not bulletproof. Three systemic gaps: (1) the UI lies about data freshness, (2) there is no
+last-known-good fallback anywhere, so any upstream blip becomes a user-visible failure, and
+(3) nothing detects or alerts on degradation. Plus several outright bugs that hit hardest on
+earnings night — the exact moment the dashboard exists for.
+
+---
+
+## P0 — Correctness bugs (the dashboard shows wrong things)
+
+### P0.1 Post-market misclassified as CLOSED on every normal weekday
+`src/utils/marketState.js:72` — `isHoliday = !weekend && !isOpen && nextOpen !== today`. After the
+4pm bell, Alpaca's `next_open` is tomorrow, so every normal evening is flagged as a holiday →
+state forced CLOSED, never POST_MARKET. Consequences:
+- Extended-hours polling (`StockTracker.jsx:828`, gated on `isExtendedHours`) never runs post-close
+  → the post-market price is frozen. TSLA earnings are aftermarket (`config.js:5`), so the most
+  important move of the quarter doesn't update.
+- `determineInitialPhase` (`pricePhase.js:28`) can't return SETTLED/SETTLING on evening cold-loads.
+- The POST_MARKET today-row branch (`StockTracker.jsx:958`) is effectively dead code.
+**Fix:** only treat "not open + next_open ≠ today" as holiday when *before* the open; between
+16:00–20:00 ET on a weekday, classify POST_MARKET. Better: expose Alpaca's calendar via the worker.
+
+### P0.2 EARNINGS_DATE timezone parse — earnings night never triggers from the UK
+`EarningsControlCentre.jsx:33` — `dayjs(CONFIG.earningsDate).tz(EST)` parses `'2026-04-22'` as
+*local* midnight then converts, shifting the date to the 21st for any viewer at/east of UTC.
+`isEarningsNight` is then false on the real night → no 5s polling, no LIVE banner. You're in the UK,
+so this bug affects you every quarter.
+**Fix:** `dayjs.tz(CONFIG.earningsDate, EST)` (parse *in* EST).
+Related (H): `EARNINGS_DATE` is a manual constant — forget to update it and live mode silently
+never arms. Derive next earnings date from the Finnhub calendar (worker already fetches it) with
+the constant as override only.
+
+### P0.3 Earnings validation system is dead code on the live path
+`useEarningsData.js:96` waits for `result.pendingSources?.length > 0 && result.allResults > 1`,
+but the worker race response (`worker.js:1540-1547`) never emits those fields → the merge upgrade
+never fires. The worker *does* background-merge into KV (`worker.js:1509-1538`), but subsequent
+reads only serve stored data when `stored.manual === true` (`worker.js:1306`) — so cross-validated
+data is written and never surfaced. On earnings night the UI shows single-source numbers with no
+DiscrepancyWarning and no `validated ✓` all night. The confidence UI plumbing exists and is ~90%
+wired — it just never receives live data.
+**Fix:** serve the background-merged KV record on subsequent polls (freshness check instead of the
+`manual` gate), and/or race once for fast paint then poll merge mode.
+
+### P0.4 Race mode can display last quarter's numbers as live
+`worker.js:1497-1547` — race takes the first source returning *any* data, no quarter check (merge
+mode has one at `worker.js:1207`). Finnhub `/stock/earnings` often still holds the prior quarter
+right after a release and returns no error, so it can win → dashboard shows Q-1 actuals as if live.
+Also: a single-source winner means EPS-only or revenue-only sources leave the other metric "N/A"
+all night (`EarningsData.jsx:110-129`).
+**Fix:** reject race winners whose quarter isn't in the expected window; prefer sources with both
+metrics (finnhub-calendar, EDGAR) on earnings night.
+
+### P0.5 "Last updated" always shows the current time
+`StockTracker.jsx:1200` renders `dayjs().format(...)` — wall-clock at render, and the component
+re-renders every second. A frozen price shows a fresh timestamp indefinitely.
+**Fix:** track a real `lastUpdatedAt` set only when a price actually lands (WS onmessage :675,
+fallback :882, fetchStockData :181); render that.
+
+---
+
+## P1 — Resilience (survive upstream blips; stop self-inflicted outages)
+
+### P1.1 No last-known-good fallback anywhere for core price data
+Worker: quote/clock/bars/chart have no KV persistence — cache miss + upstream down = error to the
+client (`worker.js` §2). Frontend: `clearCaches(ticker)` runs on every mount
+(`StockTracker.jsx:506`) *before* `getCachedData` (:152), so the 1-hour localStorage cache never
+serves a paint; on total outage `resolvePrice` returns 0 and the box renders **$0.00**
+(`pricePhase.js:51`, `StockTracker.jsx:1090`).
+**Fix:** worker writes last-known-good quote/clock to KV via `ctx.waitUntil` on every success and
+serves it tagged `stale: true` on upstream failure. Frontend stops clearing cache on mount, serves
+cached bars for instant first paint, and keeps a last-good quote to render clearly labelled stale.
+
+### P1.2 No connection/staleness indicator
+`StockTracker.jsx:1097` — the status dot only encodes market open/closed, never connection health.
+Dead WS + failing fallback is visually identical to live.
+**Fix:** live / delayed / offline badge driven by WS state + last-update age; stale banner when
+last successful update > ~20s during regular hours or price is 0.
+
+### P1.3 Free-tier quota exhaustion (self-inflicted outage)
+`worker.js:701-721, 803-866, 1414-1436` — `/fmp/*` routes and AlphaVantage merge calls are
+uncached or edge-cached only. FMP = 250 calls/day, AV = 25/day; `caches.default` is per-colo and
+best-effort so "24h TTL" does not mean one call/day. `/fmp/sp500-weight` does 1+N calls per cache
+miss. A dozen earnings-day visitors exhaust AV in minutes, FMP within the hour → errors for
+everyone for the rest of the day.
+**Fix:** KV-backed response caching (cross-colo, durable) with sane TTLs; KV daily budget counter
+per provider that serves last-known-good once near the cap; backoff on 429.
+
+### P1.4 No timeouts on most upstream fetches
+Only `proxyFetch` (worker.js:315) has an AbortController. All finnhub/fmp/av/edgar/yahoo/news
+fetches, and all in-component fetches in StockTracker (bars :154, chart :287, intraday :356,
+weekly :392, monthly :421, more-history :253, sort :1040 — also missing `res.ok` checks), can hang
+indefinitely. In merge mode one hung source stalls the entire earnings response
+(`Promise.all`, worker.js:1560). `fetchMoreHistory`/`handleSort` wedge `isFetchingMore=true`
+forever on a hang.
+**Fix:** shared `fetchWithTimeout` (5–8s) on every worker upstream call; per-source timeout in
+merge; route StockTracker's raw fetches through the existing `api.js` fetchWithTimeout + ok checks.
+
+### P1.5 Zero observability — degradation is invisible until a user notices
+No `/health`, no cron heartbeat, no alerting. If the news cron dies, `news:TSLA` serves stale KV
+for 7 days then expires to empty ("No news yet"); the frontend shows `Last refreshed: {new Date()}`
+(`TeslaNews.jsx:45`) — client fetch time, not collection time — so staleness is invisible
+(worker returns `lastCollected` at :498; frontend ignores it).
+**Fix:** `GET /health` returning KV reachability, `lastCollected` age, provider/key status, cron
+heartbeat age; write a heartbeat key each cron run; point an external uptime monitor at it (VPS
+cron + email/alert would do); frontend shows "collected Xm ago" and warns > 60min.
+
+### P1.6 Market-open edge: overnight tab keeps yesterday's baseline
+`StockTracker.jsx:551-560` refetches on the open→close edge but there's no close→open equivalent;
+`quote.pc/o` and day high/low stay a day stale, so every change/% is computed against yesterday's
+close until manual reload.
+**Fix:** mirror the close-edge effect: on `isOpen false→true`, `clearCaches` + `fetchStockData`.
+
+### P1.7 WebSocket resilience gaps
+- Zombie window (`StockTracker.jsx:594, 781, 872`): silently-dead socket keeps `wsAvailable=true`
+  → fallback suppressed up to ~75s with no update mechanism at all. Proactively flip to polling
+  when `now - lastMessageTime` exceeds a smaller bound.
+- Orphaned reconnect timer (`:748-751` vs `:769-772`): health-check reconnect never clears a
+  pending `reconnectTimeout` → later double-connect tears down a healthy socket (bad on Finnhub's
+  1-connection free tier); health check also resets `reconnectAttempts`, defeating backoff.
+  Clear the timer at `connectWebSocket` entry; unify reconnect paths.
+- No `visibilitychange` handler — post-wake recovery waits on the 15s health check. Add
+  visible→ force health check + one immediate fetch.
+
+### P1.8 Earnings-night fetch starvation + hot-key KV writes
+- `useEarningsData.js:47-50`: every 5s poll aborts the in-flight request; if unified takes >5s
+  (races slow upstreams uncached), data never lands — UI sits loading with AbortError swallowed.
+  Skip the tick when a request is in flight; abort only on ticker change.
+- `worker.js:1528-1533, 1589-1596, 1671-1678`: every merge/race-background writes the same
+  `earnings:SYM:latest/history` keys — KV allows 1 write/sec/key; concurrent earnings-night users
+  → dropped writes, lost-update race on history. Debounce/single-writer.
+
+---
+
+## P2 — Hardening and polish
+
+| # | Finding | Where | Fix |
+|---|---------|-------|-----|
+| 1 | `/fmp/earnings-surprises` returns HTTP 200 on upstream errors (no status forwarded, no ok check; also uses FMP's deprecated /api/v3) | worker.js:713-721 | route through proxyFetch |
+| 2 | `/yahoo-quote` uses deprecated Yahoo v6 quote endpoint — likely 401s | worker.js:1747 | migrate to v8; verify frontend dependence |
+| 3 | Earnings "BEAT by $0.00" when estimate is null (`null >= 0` → true) | EarningsData.jsx:116 | gate on `surprise != null` |
+| 4 | Revenue discrepancies never recorded → conflicting revenue can show `validated ✓` | worker.js:1249-1263 | mirror EPS discrepancy check |
+| 5 | Selecting a historical quarter is clobbered by the next poll within 5–30s | useEarningsData.js:149,193 | pause live overwrite while browsing + "back to live" |
+| 6 | "Refresh News" sends no auth → 401 swallowed, appears to work | TeslaNews.jsx:53-64, worker.js:506 | check response.ok, decide auth contract |
+| 7 | "Add tweet" POSTs `/news/tweet` — route doesn't exist (404) | TeslaNews.jsx:80 | implement or remove form |
+| 8 | Earnings CNBC panel: 15s polling of an uncached live Google RSS scrape, silent failure | earnings/NewsFeed.jsx:9-26, worker.js:427 | KV-cache 5min, error state, back off |
+| 9 | `earningsNight` flips up to 5min late (driven by 5-min clock fetch) | EarningsControlCentre.jsx:81,129 | drive off the 30s ticking clock |
+| 10 | Full-page spinner gates ready earnings data behind the price fetch | EarningsControlCentre.jsx:208 | per-panel loading |
+| 11 | Price box requires historical bars to render; quote serialized behind bars fetch | StockTracker.jsx:177 | decouple; set quote from priceData alone |
+| 12 | EDGAR companyfacts is 20–50MB parsed in-worker for big tickers | worker.js:914,1349 | use companyconcept; KV-cache result |
+| 13 | News-store KV "lock" is racy (eventual consistency) and discards items when contended | worker.js:234-260 | single-writer via cron; don't drop on contention |
+| 14 | Corrupt earnings KV blob → 500 instead of live-fetch fallthrough | worker.js:1305 | wrap, fall through |
+| 15 | Unguarded `res.json()` in /alphavantage, /exchange-rate, sp500 sub-parses | worker.js:822,1828,740-758 | guard, stale-fallback |
+| 16 | sp500-weight caches partial results 24h; hardcoded divisor drifts | worker.js:764-792 | don't cache partials |
+| 17 | Exchange-rate fallback only set on throw, not on non-OK → £ sign on $ numbers | StockTracker.jsx:913-921 | set fallback on !ok |
+| 18 | `/clock`, `/fmp/shares-float`, `/news/cnbc` have no Cache-Control | worker.js:467 etc | add short caches |
+| 19 | proxyFetch stamps Content-Type: application/json on HTML error bodies | worker.js:323 | forward upstream type |
+| 20 | CIK map duplicated; GOOG missing from the second copy | worker.js:873,1322 | single constant |
+| 21 | Symbol path segment uninterpolated-validated | worker.js:628 | `^[A-Z.\-]{1,6}$` guard |
+| 22 | "Invalid Date"/"NaN ago" on missing publishedAt; index React keys; ÷0 in change% | TeslaNews.jsx:5,168; PriceDisplay.jsx:26 | guards, stable keys |
+| 23 | setState-after-unmount: uncancelled 3s timeout, unguarded quarter fetches | useEarningsData.js:97,113-165 | clear timers, mounted guard |
+| 24 | Clock-fetch failure loses holiday awareness (local fallback shows open on holidays) | marketState.js:51-63, api.js:30 | acceptable; note only |
+| 25 | SEEN_URLS write pressure near free-tier KV budget on busy days | worker.js cron | watch; bounded by TTL |
+
+---
+
+## Already good (don't touch)
+- Worker: outer try/catch always returns a Response; proxyFetch pattern (timeout+status forwarding);
+  news collectors isolated with partial-failure tolerance; cron errors caught; SEEN_URLS 30-day TTL;
+  race correctly rejects fast *errors* (only data wins); Bearer auth on mutation routes; WS proxy
+  keeps Finnhub key server-side; EDGAR YTD-contamination filter; discrepancy/confidence engine.
+- Frontend: api.js fetchWithTimeout; abort-per-ticker with signal guards (no cross-ticker bleed);
+  WS resubscribes on reconnect; health check does eventually catch zombies; settle state machine +
+  resolvePrice single source of truth; ErrorBoundary; cache.js fully guarded (corrupt JSON, quota).
+- Earnings hook: recursive setTimeout (no drift/pile-up); tab-hidden throttling + refocus refresh;
+  no-store on unified; confidence UI primitives all exist (just not fed — see P0.3).
+
+## Suggested sequencing
+1. **P0.1–P0.5** — small, surgical fixes; each makes the dashboard stop being *wrong*.
+2. **P1.1–P1.5** — the bulletproofing layer: last-known-good + staleness honesty + quota budget +
+   timeouts + /health with an external monitor.
+3. **P1.6–P1.8**, then P2 quick wins opportunistically (1, 3, 6, 7, 17 are minutes each).
+
+Verification notes: P0.1/P0.2 are testable locally by mocking the Alpaca clock and setting a fake
+EARNINGS_DATE; P0.3/P0.4 need a worker deploy + `mode=race` inspection; WS behaviour (P1.7) must be
+tested during US market hours per project rules.


### PR DESCRIPTION
Implements step 1 of `tasks/all-in-reliability-audit.md` (2 July) — the five P0 bugs where the dashboard shows wrong things. Audit doc is included in this PR with an implementation-status section.

## Fixes

- **P0.1 — post-market misclassified as CLOSED every weekday evening** (`src/utils/marketState.js`): holiday detection (`next_open ≠ today`) is only decidable before the open — after the 4pm bell `next_open` is always tomorrow, which flagged every normal evening as a holiday. Extended-hours polling, evening SETTLED cold-loads and the POST_MARKET today-row all come back to life. Trade-off: a holiday evening now reads POST_MARKET; the synthetic today-row is guarded by `quote.tradingDay === today` so no phantom row appears.
- **P0.2 — earnings night never armed from the UK** (`EarningsControlCentre.jsx`): `dayjs(date).tz(EST)` parsed at the viewer's local midnight, shifting the calendar day for anyone at/east of UTC. Now `dayjs.tz(date, EST)`.
- **P0.3 — cross-validation was dead code on the live path** (`worker.js` + `useEarningsData.js`): the worker now serves the background-merged KV record when `lastUpdated` < 60s (manual still always wins), so poll N races and poll N+1 gets the validated record with confidence + discrepancies. The frontend's never-true `pendingSources` branch is replaced with a merge follow-up keyed on `result.mode === 'race'`. Also wraps the KV read so a corrupt blob falls through to live fetch instead of 500ing (audit P2.14). Side benefit: most earnings-night polls become KV hits, cutting free-tier quota burn.
- **P0.4 — race could show last quarter's numbers right after a release** (`worker.js`): biased race — finnhub-calendar (the only source pinned to a freshly-released quarter, with both EPS and revenue) gets a 1.5s head start before falling back to `Promise.any`. Costs nothing when the calendar errors fast, and race mode is only used on earnings night.
- **P0.5 — "Last updated" always showed the current time** (`StockTracker.jsx`): real `lastUpdatedAt` stamped at every price-landing point (initial fetch, WS tick, fallback poll, extended-hours poll, settle reads), reset on ticker change; renders `—` until the first price lands.

## Verification

- `npm run build` clean.
- `scripts/test-market-state.mjs` (new, permanent): 8-case matrix through the real `marketState.js` with frozen clock + mocked Alpaca data — all pass, including pre-market/holiday-morning non-regressions and the documented holiday-evening trade-off.
- `scripts/test-earnings-night-tz.mjs` (new, permanent): proves the old parse fails from London/Tokyo and the fix arms in all TZs (no-op for US viewers). Rerun each quarter after updating `EARNINGS_DATE`.
- Worker: `wrangler deploy --dry-run` bundles clean; local miniflare probe of `/earnings/unified/TSLA?mode=race` exercised the new biased-race path end-to-end (calendar 401s without keys → instant fallback → EDGAR won with live Q1-2026 revenue).
- WS behaviour untouched; market-hours live test not possible today (4 July holiday).

## Deploy note

Worker changes need `npm run deploy:worker` after merge; the frontend auto-deploys from main via Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)